### PR TITLE
Removes commenting tags from markdown export template

### DIFF
--- a/packages/common/services/markdown.js
+++ b/packages/common/services/markdown.js
@@ -21,13 +21,13 @@ class Markdown {
 
     for (let page of pages) {
       const { meta, notes } = page;
-      data += `<!-- # [${meta.title}](${meta.url}) -->\n\n`;
+      data += `# [${meta.title}](${meta.url}) \n\n`;
 
       for (let note of notes) {
-        data += `<!-- ## [${secondsToTime(note.timestamp)}](${buildAutoSeekUrl(
+        data += `## [${secondsToTime(note.timestamp)}](${buildAutoSeekUrl(
           meta.url,
           note.timestamp
-        )}) -->\n\n`;
+        )}) \n\n`;
         data += note.content + '\n\n';
       }
     }

--- a/packages/common/services/markdown.js
+++ b/packages/common/services/markdown.js
@@ -21,13 +21,13 @@ class Markdown {
 
     for (let page of pages) {
       const { meta, notes } = page;
-      data += `# [${meta.title}](${meta.url}) \n\n`;
+      data += `# [${meta.title}](${meta.url})\n\n`;
 
       for (let note of notes) {
         data += `## [${secondsToTime(note.timestamp)}](${buildAutoSeekUrl(
           meta.url,
           note.timestamp
-        )}) \n\n`;
+        )})\n\n`;
         data += note.content + '\n\n';
       }
     }


### PR DESCRIPTION
fix: removes commenting tags from markdown template

removes commenting tags from markdown export template.

Resolves: #84 