### PR TITLE
docs: fix name of GNU GPL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,4 +234,4 @@ Youtube don't update page metas, like title and thumbnails, when video changed i
 
 Copyright (c) 2016 - 2020
 
-Licensed under the GUN GPL3.0 License. [View license](/LICENSE)
+Licensed under the GNU GPL3.0 License. [View license](/LICENSE)


### PR DESCRIPTION
The correct name of the license is GNU GPL and not GUN GPL.

This pull request addresses this issue and changes the license name in the file `README.md` from `GUN GPL3.0` to `GNU GPL3.0`.